### PR TITLE
Implement time nocallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-data/*.xlsx
+data/*.csv
 data/*.pkl
 logs/
 *.pyc

--- a/app.py
+++ b/app.py
@@ -4,23 +4,10 @@ import dash
 import dash_core_components as dcc
 import dash_html_components as html
 import pandas as pd
-import plotly.graph_objects as go
-from dash.dependencies import Input, Output
 
-geometry = pd.read_pickle("data/geom.pkl").to_dict()
 data = pd.read_pickle("data/data.pkl")
-curr_data = pd.read_pickle("data/curr_data.pkl")
 latest = data["date"].max().strftime("%Y-%m-%d")
-date_dict = (
-    data["date"]
-    .drop_duplicates()
-    .dropna()
-    .sort_values()
-    .reset_index(drop=True)
-    .to_dict()
-)
-last_date_idx = max(list(date_dict.keys()))
-max_z = round(data["rate_14_day_per_100k"].max(), -3)
+fig = pd.read_pickle("data/figure.pkl")[0]
 
 external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 auth_lst = [
@@ -39,63 +26,8 @@ auth_lst = [
 author = html.Div(auth_lst)
 app = dash.Dash(__name__, title="Eurocovid", external_stylesheets=external_stylesheets)
 app.layout = html.Div(
-    [
-        dcc.Graph(id="map"),
-        html.Div(id="update_slider_text", style={"padding-left": "5%"}),
-        html.Div(
-            dcc.Slider(
-                id="time_slider", min=0, max=last_date_idx, step=1, value=last_date_idx,
-            ),
-            style={"width": "50%", "padding-left": "5%"},
-        ),
-        html.Div(author, style={"padding-top": "2%", "padding-left": "5%"}),
-    ]
+    [dcc.Graph(figure=fig), html.Div(author, style={"padding-top": "5%"})]
 )
-
-
-@app.callback(Output("update_slider_text", "children"), [Input("time_slider", "value")])
-def display_value(time_idx):
-    return "Change date: {}".format(date_dict[time_idx].strftime("%Y-%m-%d"))
-
-
-@app.callback(Output("map", "figure"), [Input("time_slider", "value")])
-def map_gen(time_idx):
-    if time_idx == last_date_idx:
-        plot_data = curr_data
-    else:
-        plot_data = data.loc[data["date"] <= date_dict[time_idx]]
-        plot_data = (
-            plot_data.groupby("nuts_code")
-            .apply(lambda x: x.sort_values("date").iloc[-1])
-            .reset_index(drop=True)
-        )
-    fig = go.Figure(
-        go.Choroplethmapbox(
-            geojson=geometry,
-            locations=plot_data["nuts_code"],
-            z=plot_data["rate_14_day_per_100k"],
-            colorscale="Magma_r",
-            marker_opacity=0.9,
-            marker_line_width=0,
-            zmin=0,
-            zmax=max_z,
-            text=plot_data["region_name"]
-            + " ("
-            + plot_data["country"]
-            + "): "
-            + plot_data["date"].dt.strftime("%Y-%m-%d"),
-        )
-    )
-    fig.update_layout(
-        title_text="14-day COVID-19 case notification rate per 100 000",
-        title_x=0.5,
-        width=1000,
-        height=700,
-        uirevision=True,
-        mapbox=dict(center=dict(lat=54, lon=6.7), style="carto-positron", zoom=2.6),
-    )
-    return fig
-
 
 if __name__ == "__main__":
     app.run_server(debug=False)

--- a/app.py
+++ b/app.py
@@ -5,33 +5,23 @@ import dash_core_components as dcc
 import dash_html_components as html
 import pandas as pd
 import plotly.graph_objects as go
+from dash.dependencies import Input, Output
 
 geometry = pd.read_pickle("data/geom.pkl").to_dict()
 data = pd.read_pickle("data/data.pkl")
-fig = go.Figure(
-    go.Choroplethmapbox(
-        geojson=geometry,
-        locations=data["nuts_code"],
-        z=data["rate_14_day_per_100k"],
-        colorscale="Magma_r",
-        marker_opacity=0.9,
-        marker_line_width=0,
-        text=data["region_name"]
-        + " ("
-        + data["country"]
-        + "): "
-        + data["date"].dt.strftime("%Y-%m-%d"),
-    )
+curr_data = pd.read_pickle("data/curr_data.pkl")
+latest = data["date"].max().strftime("%Y-%m-%d")
+date_dict = (
+    data["date"]
+    .drop_duplicates()
+    .dropna()
+    .sort_values()
+    .reset_index(drop=True)
+    .to_dict()
 )
-fig.update_layout(
-    title_text="14-day COVID-19 case notification rate per 100 000",
-    title_x=0.5,
-    width=1000,
-    height=700,
-    mapbox=dict(center=dict(lat=54, lon=6.7), style="carto-positron", zoom=2.6),
-)
+last_date_idx = max(list(date_dict.keys()))
+max_z = round(data["rate_14_day_per_100k"].max(), -3)
 
-# Dash app
 external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 auth_lst = [
     html.P("Created by ", style={"display": "inline"}),
@@ -44,11 +34,68 @@ auth_lst = [
         href="https://github.com/pepicello/eurocovid",
         style={"display": "inline"},
     ),
-    html.P(".", style={"display": "inline"}),
+    html.P(f". Latest update: {latest}", style={"display": "inline"}),
 ]
 author = html.Div(auth_lst)
 app = dash.Dash(__name__, title="Eurocovid", external_stylesheets=external_stylesheets)
-app.layout = html.Div([dcc.Graph(figure=fig), author])
+app.layout = html.Div(
+    [
+        dcc.Graph(id="map"),
+        html.Div(id="update_slider_text", style={"padding-left": "5%"}),
+        html.Div(
+            dcc.Slider(
+                id="time_slider", min=0, max=last_date_idx, step=1, value=last_date_idx,
+            ),
+            style={"width": "50%", "padding-left": "5%"},
+        ),
+        html.Div(author, style={"padding-top": "2%", "padding-left": "5%"}),
+    ]
+)
+
+
+@app.callback(Output("update_slider_text", "children"), [Input("time_slider", "value")])
+def display_value(time_idx):
+    return "Change date: {}".format(date_dict[time_idx].strftime("%Y-%m-%d"))
+
+
+@app.callback(Output("map", "figure"), [Input("time_slider", "value")])
+def map_gen(time_idx):
+    if time_idx == last_date_idx:
+        plot_data = curr_data
+    else:
+        plot_data = data.loc[data["date"] <= date_dict[time_idx]]
+        plot_data = (
+            plot_data.groupby("nuts_code")
+            .apply(lambda x: x.sort_values("date").iloc[-1])
+            .reset_index(drop=True)
+        )
+    fig = go.Figure(
+        go.Choroplethmapbox(
+            geojson=geometry,
+            locations=plot_data["nuts_code"],
+            z=plot_data["rate_14_day_per_100k"],
+            colorscale="Magma_r",
+            marker_opacity=0.9,
+            marker_line_width=0,
+            zmin=0,
+            zmax=max_z,
+            text=plot_data["region_name"]
+            + " ("
+            + plot_data["country"]
+            + "): "
+            + plot_data["date"].dt.strftime("%Y-%m-%d"),
+        )
+    )
+    fig.update_layout(
+        title_text="14-day COVID-19 case notification rate per 100 000",
+        title_x=0.5,
+        width=1000,
+        height=700,
+        uirevision=True,
+        mapbox=dict(center=dict(lat=54, lon=6.7), style="carto-positron", zoom=2.6),
+    )
+    return fig
+
 
 if __name__ == "__main__":
     app.run_server(debug=False)

--- a/data.py
+++ b/data.py
@@ -44,6 +44,9 @@ if __name__ == "__main__":
     data["nuts_code"] = data["nuts_code"].astype(str).replace(nuts_dict, regex=True)
     data = data.loc[~data.nuts_code.isin(nuts_mapping["delete"])]
 
+    # Round number of cases
+    data["rate_14_day_per_100k"] = data["rate_14_day_per_100k"].round()
+    
     # geoJson for nuts codes (EU)
     geometry = {}
     for level in [0, 1, 2, 3]:

--- a/fig.py
+++ b/fig.py
@@ -1,0 +1,56 @@
+""" Create figure object """
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+sel_col = [
+    "date",
+    "current_date",
+    "nuts_code",
+    "rate_14_day_per_100k",
+    "region_name",
+    "country",
+]
+rename_cols = dict(rate_14_day_per_100k="Rate", region_name="Region", country="Country")
+
+geometry = pd.read_pickle("data/geom.pkl").to_dict()
+data = pd.read_pickle("data/data.pkl")
+data = data[sel_col]
+data["Update Date"] = data["date"].dt.strftime("%Y-%m-%d")
+data["Current Date"] = data["current_date"].dt.strftime("%Y-%m-%d")
+data = data.rename(columns=rename_cols)
+data = data.sort_values("current_date")
+max_z = round(data["Rate"].max(), -3)
+
+fig = px.choropleth_mapbox(
+    data,
+    geojson=geometry,
+    locations="nuts_code",
+    color="Rate",
+    color_continuous_scale="Magma_r",
+    range_color=(0, max_z),
+    mapbox_style="carto-positron",
+    opacity=0.9,
+    center={"lat": 54, "lon": 6.7},
+    title="<b>14-day COVID-19 case notification rate per 100 000</b>",
+    zoom=2.4,
+    hover_name="Region",
+    hover_data={
+        "Current Date": False,
+        "nuts_code": False,
+        "Rate": True,
+        "Country": True,
+        "Update Date": True,
+    },
+    animation_frame="Current Date",
+    width=1000,
+    height=700,
+)
+
+fig.layout["sliders"][0]["active"] = len(fig.frames) - 1
+fig = go.Figure(data=fig["frames"][-1]["data"], frames=fig["frames"], layout=fig.layout)
+fig.update_geos(fitbounds="locations", visible=False)
+fig.update_traces(marker_line_width=0)
+
+pd.Series({0: fig}).to_pickle("data/figure.pkl")


### PR DESCRIPTION
Implementing a time slider. The website is slightly slower to load at the beginning but it is fast to re-draw map between dates. A choroplethmapbox object is stored as a pickle whenever data is updated to partially fix this problem.

Another implementation using dash call backs was discontinued: it was faster to load at startup, but it took a couple of seconds to re-draw map between callbacks and did not have an animation button in the slider. It is left in this [stale branch](/pepicello/eurocovid/tree/implement_time).